### PR TITLE
Fixed error in composer.json resulting in incompatibility with Symfony 3.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": ">=5.3.9",
-        "symfony/framework-bundle": "~2.3|3.*",
+        "symfony/framework-bundle": "~2.3||3.*",
         "caxy/php-htmldiff": "~0.1"
     },
     "require-dev": {


### PR DESCRIPTION
There was a typo in the composer.json, so it was not installable in Symfony 3.x.

From https://getcomposer.org/doc/articles/versions.md#range:

> A double pipe (||) will be treated as a logical OR. 