### PR TITLE
Resolved Symfony 3.x deprecation warnings

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": ">=5.3.9",
-        "symfony/framework-bundle": "~2.3|3.*",
+        "symfony/framework-bundle": "~2.3||3.*",
         "caxy/php-htmldiff": "~0.1"
     },
     "require-dev": {

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -5,14 +5,14 @@ parameters:
 
 services:
     caxy.html_diff.config:
-        class: %caxy.html_diff.config.class%
-        factory: [%caxy.html_diff.config.class%, create]
+        class: "%caxy.html_diff.config.class%"
+        factory: ["%caxy.html_diff.config.class%", create]
     caxy.html_diff:
-        class: %caxy.html_diff.class%
+        class: "%caxy.html_diff.class%"
         calls:
             - [setConfig, ["@caxy.html_diff.config"]]
     caxy.twig.html_diff_extension:
-        class: %caxy.twig.html_diff_extension.class%
+        class: "%caxy.twig.html_diff_extension.class%"
         arguments: ["@service_container"]
         tags:
             - { name: twig.extension }


### PR DESCRIPTION
Example:

> Not quoting the scalar "%caxy.html_diff.config.class%" starting with the "%" indicator character is deprecated since Symfony 3.1 and will throw a ParseException in 4.0.