### PR TITLE
Fix deprecation on sf6/sf7

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Symfony Bundle for [caxy/php-htmldiff][0].
 
 ## Requirements
 
-- PHP 5.3.3 or higher
+- PHP 7.1 or higher
 - [caxy/php-htmldiff][0]
 
 ## Installation

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
         }
     ],
     "require": {
-        "php": ">=7.0",
-        "symfony/framework-bundle": "~2.3||3.*||4.*||5.*||6.*",
+        "php": ">=7.1",
+        "symfony/framework-bundle": "4.*||5.*||6.*||7.*",
         "caxy/php-htmldiff": "~0.1"
     },
     "require-dev": {

--- a/src/DependencyInjection/CaxyHtmlDiffExtension.php
+++ b/src/DependencyInjection/CaxyHtmlDiffExtension.php
@@ -36,7 +36,7 @@ class CaxyHtmlDiffExtension extends Extension
     /**
      * {@inheritDoc}
      */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
@@ -63,7 +63,7 @@ class CaxyHtmlDiffExtension extends Extension
      * @param ContainerBuilder $container
      * @param string           $cacheDriverId
      */
-    protected function loadHtmlDiffConfig(array $config, ContainerBuilder $container, $cacheDriverId = null)
+    protected function loadHtmlDiffConfig(array $config, ContainerBuilder $container, $cacheDriverId = null): void
     {
         $loader = new YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yml');
@@ -100,7 +100,7 @@ class CaxyHtmlDiffExtension extends Extension
      * @return string
      * @throws \Exception
      */
-    protected function loadCacheDriver($cacheName, array $driverMap, ContainerBuilder $container)
+    protected function loadCacheDriver($cacheName, array $driverMap, ContainerBuilder $container): string
     {
         if (null === $this->cacheProviderLoader) {
             throw new \Exception('DoctrineCacheBundle required to use doctrine_cache_driver.');


### PR DESCRIPTION
Fix a deprecation for sf6.4 and upgrade php to 7.1 and remove support for sf2.3 and sf3.